### PR TITLE
Add parsing of variables from companion

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -151,6 +151,7 @@ module.exports = {
 					type: 'textinput',
 					label: 'Value of Variable to Set',
 					tooltip: 'To trigger a visibility variable, set to anything for `visible` and leave empty for `invisible`.',
+					useVariables: true,
 				})
 				break
 			case 'variableIncrementAction':
@@ -185,7 +186,7 @@ module.exports = {
 			default: 'update',
 		})
 
-		action.callback = (action) => {
+		action.callback = async (action) => {
 			// console.log('user used action:')
 			// console.dir(action, {depth: 5})
 
@@ -215,7 +216,8 @@ module.exports = {
 
 			switch (shortId) {
 				case 'variableSetAction':
-					newValue = action.options.varvalue ?? ''
+					// parse variables from the input text
+					newValue = await this.parseVariablesInString(action.options.varvalue ?? '')
 					break
 				case 'variableIncrementAction':
 					newValue = makeNumber(action.options.varincrement) + makeNumber(prevValue)


### PR DESCRIPTION
This change allows for the update variable action to take in a companion variable and parse it before updating it in the Captivate graphic. All of the other actions still work based on what I've tested.